### PR TITLE
Add documentation directory

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+# Hello World

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,11 @@
-# Hello World
+# Project Headline [![Lisence](https://img.shields.io/packagist/v/projek-xyz/template?style=flat-square)](https://packagist.org/packages/projek-xyz/template)
+
+Some descriptive project description.
+
+## Requirements
+
+- List of the requirements.
+
+## Installation
+
+How to install

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,2 @@
-theme: jekyll-theme-cayma
+title: "Projek-XYZ Template Documentation"
+remote_theme: pmarsceill/just-the-docs

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,2 +1,2 @@
-title: "Projek-XYZ Template Documentation"
+title: "Projek-XYZ Template"
 remote_theme: pmarsceill/just-the-docs

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayma


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add `docs` directory which is basically a `jekyll` site with [@pmarsceill/just-the-docs](https://github.com/pmarsceill/just-the-docs) as default `remote_theme`. [Read more](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other
